### PR TITLE
Fix scroll issue on the external review screen

### DIFF
--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/PagePreview/Index.cshtml
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/PagePreview/Index.cshtml
@@ -34,7 +34,7 @@
                 line-height: 14px;
             }
         </style>
-    </head><body style="width: 100%; height: 100%;"><div id="reviews-editor" data-url="./AddPin" data-user="@HttpContext.Current.User.Identity.Name" data-pins="@Model.ReviewPins"></div>
+    </head><body style="width: 100%; height: 100%; font-size: 0"><div id="reviews-editor" data-url="./AddPin" data-user="@HttpContext.Current.User.Identity.Name" data-pins="@Model.ReviewPins"></div>
         <iframe id="editableIframe" src="@Model.EditableContentUrlSegment" width="100%" height="100%"></iframe>
 
         <script type="text/javascript">

--- a/src/ui/iframe-overlay/iframe-overlay.tsx
+++ b/src/ui/iframe-overlay/iframe-overlay.tsx
@@ -66,8 +66,18 @@ export default class IframeOverlay extends React.Component<IframeOverlayProps, a
             return;
         }
 
+        const scrollLeft = e.srcElement.scrollLeft;
+        const scrollTop = e.srcElement.scrollTop;
+
+        const body = this.props.iframe.parentNode as HTMLBodyElement;
+        if (body) {
+            this.props.iframe.contentWindow.scrollTo(scrollLeft, scrollTop);
+            return;
+        }
+
         const previewContainer = this.props.iframe.parentNode as HTMLElement;
-        previewContainer.scrollTop = e.srcElement.scrollTop;
+        previewContainer.scrollLeft = scrollLeft;
+        previewContainer.scrollTop = scrollTop;
     }
 
     addReviewLocation(e) {


### PR DESCRIPTION
If the iframe is a direct child of the 'body' node we should use
a different method to sync the scroll.

Closes #57