### PR TITLE
Restyle closed tasks view

### DIFF
--- a/src/ui/src/details/review-details.tsx
+++ b/src/ui/src/details/review-details.tsx
@@ -123,9 +123,6 @@ export class ReviewDetails extends React.Component<ReviewDetailsProps, NewPinDto
                         </div>
                     </>
                 )}
-                {this.props.currentEditLocation.isDone && (
-                    <Button onClick={this.props.onCancel}>{res.panel.gobacktolist}</Button>
-                )}
             </div>
         );
     }

--- a/src/ui/src/pin-navigator/pin-navigator.tsx
+++ b/src/ui/src/pin-navigator/pin-navigator.tsx
@@ -9,10 +9,12 @@ import "@material/react-material-icon/index.scss";
 import "./pin-navigator.scss";
 
 interface PinNavigatorProps {
+    resources?: ReviewResources;
     reviewStore?: IReviewComponentStore;
 }
 
 @inject("reviewStore")
+@inject("resources")
 @observer
 export default class PinNavigator extends React.Component<PinNavigatorProps, any> {
     showReview(incrementBy: number): void {
@@ -29,6 +31,7 @@ export default class PinNavigator extends React.Component<PinNavigatorProps, any
 
     render() {
         const { reviewLocations } = this.props.reviewStore!;
+        const res = this.props.resources!;
 
         const currentItemIndex = reviewLocations.indexOf(this.props.reviewStore.editedPinLocation);
 
@@ -45,9 +48,9 @@ export default class PinNavigator extends React.Component<PinNavigatorProps, any
         }
 
         return (
-            <>
+            <div className="pin-navigator">
                 {reviewLocations.length > 1 && (
-                    <div className="pin-navigator">
+                    <>
                         <Button
                             className="next-prev-icon"
                             title={prevTitle}
@@ -67,9 +70,12 @@ export default class PinNavigator extends React.Component<PinNavigatorProps, any
                         >
                             <MaterialIcon icon="chevron_right" />
                         </Button>
-                    </div>
+                    </>
                 )}
-            </>
+                <Button className="next-prev-icon" title={res.panel.gobacktolist} aria-pressed="false">
+                    <MaterialIcon icon="list" onClick={() => (this.props.reviewStore.editedPinLocation = null)} />
+                </Button>
+            </div>
         );
     }
 }

--- a/src/ui/src/reviews-sliding-panel/reviews-sliding-panel.scss
+++ b/src/ui/src/reviews-sliding-panel/reviews-sliding-panel.scss
@@ -2,6 +2,20 @@
 
 $border: 1px solid #c0c0c0;
 
+.panel-container-settings {
+    position: absolute;
+    z-index: 705;
+    border: $border;
+    background: white;
+    border-top-left-radius: 10px;
+    border-bottom-left-radius: 10px;
+    right: 500px;
+
+    &.narrow {
+        right: 70px;
+    }
+}
+
 .panel-container {
     z-index: 700;
     position: absolute;
@@ -20,7 +34,7 @@ $border: 1px solid #c0c0c0;
         height: 100px;
 
         &.review-mode {
-            height: 235px;
+            height: 190px;
         }
 
         .filter {
@@ -28,7 +42,7 @@ $border: 1px solid #c0c0c0;
         }
 
         .type-filters {
-            border-bottom: 0;
+            border: 0;
         }
 
         .unread {

--- a/src/ui/src/reviews-sliding-panel/reviews-sliding-panel.tsx
+++ b/src/ui/src/reviews-sliding-panel/reviews-sliding-panel.tsx
@@ -176,74 +176,82 @@ export default class SlidingPanel extends React.Component<SlidingPanelProps, any
         return (
             <>
                 {!this.state.panelVisible && (
-                    <div className={classNames("panel-container narrow", filter.reviewMode ? "review-mode" : "")}>
-                        <IconButton title={res.panel.expand} onClick={this.showPanel}>
-                            <MaterialIcon icon="first_page" />
-                        </IconButton>
-                        <Legend filter={filter} />
-                    </div>
+                    <>
+                        <div className="panel-container-settings narrow">
+                            <IconButton title={res.panel.expand} onClick={this.showPanel}>
+                                <MaterialIcon icon="first_page" />
+                            </IconButton>
+                        </div>
+                        <div className={classNames("panel-container narrow", filter.reviewMode ? "review-mode" : "")}>
+                            <Legend filter={filter} />
+                        </div>
+                    </>
                 )}
                 {this.state.panelVisible && (
-                    <div className="panel-container">
-                        {editedPinLocation && (
-                            <div className="panel-header">
-                                <CheckBox
-                                    nativeControlId="resolved"
-                                    checked={this.props.reviewStore.editedPinLocation.isDone}
-                                    onChange={this.resolveTask}
-                                />
-                                <label htmlFor="resolved">{res.panel.resolved}</label>
-                                {editedPinLocation.propertyName && (
-                                    <Chip
-                                        className="property-name-label"
-                                        label={editedPinLocation.propertyName}
-                                        leadingIcon={<MaterialIcon icon="bookmark" />}
-                                        {...chipPropertyNameSettings}
+                    <>
+                        <div className="panel-container-settings">
+                            <IconButton className="close-panel" onClick={this.hidePanel} title={res.panel.collapse}>
+                                <MaterialIcon icon="last_page" />
+                            </IconButton>
+                        </div>
+                        <div className="panel-container">
+                            {editedPinLocation && (
+                                <div className="panel-header">
+                                    <CheckBox
+                                        nativeControlId="resolved"
+                                        checked={this.props.reviewStore.editedPinLocation.isDone}
+                                        onChange={this.resolveTask}
                                     />
-                                )}
-                                <PinNavigator />
-                            </div>
-                        )}
-                        {!editedPinLocation && (
-                            <>
-                                <IconButton className="close-panel" onClick={this.hidePanel} title={res.panel.collapse}>
-                                    <MaterialIcon icon="last_page" />
-                                </IconButton>
-                                <Filters filter={filter} />
-                                <h3>List of Pins</h3>
-                                <List
-                                    singleSelection
-                                    selectedIndex={this.props.reviewStore.selectedPinLocationIndex}
-                                    handleSelect={activatedIndex => this.onSelected(activatedIndex)}
-                                    className="locations"
-                                >
-                                    {reviewLocations.map(location => (
-                                        <ListItem title={res.panel.clicktoedit} key={location.id}>
-                                            <Comment
-                                                comment={location.firstComment}
-                                                isImportant={location.priority === Priority.Important}
-                                                isDone={location.isDone}
-                                            />
-                                            <IconButton
-                                                className="edit"
-                                                title={res.panel.opendetails}
-                                                onClick={e => this.onEditClick(e, location)}
-                                            >
-                                                <MaterialIcon icon="edit" />
-                                            </IconButton>
-                                        </ListItem>
-                                    ))}
-                                </List>
-                            </>
-                        )}
-                        {editedPinLocation && (
-                            <ReviewDetails
-                                onCancel={() => (this.props.reviewStore.editedPinLocation = null)}
-                                iframe={this.props.iframe}
-                                currentEditLocation={this.props.reviewStore.editedPinLocation}
-                            />
-                        )}
-                    </div>
+                                    <label htmlFor="resolved">{res.panel.resolved}</label>
+                                    {editedPinLocation.propertyName && (
+                                        <Chip
+                                            className="property-name-label"
+                                            label={editedPinLocation.propertyName}
+                                            leadingIcon={<MaterialIcon icon="bookmark" />}
+                                            {...chipPropertyNameSettings}
+                                        />
+                                    )}
+                                    <PinNavigator />
+                                </div>
+                            )}
+                            {!editedPinLocation && (
+                                <>
+                                    <Filters filter={filter} />
+                                    <h3>List of Pins</h3>
+                                    <List
+                                        singleSelection
+                                        selectedIndex={this.props.reviewStore.selectedPinLocationIndex}
+                                        handleSelect={activatedIndex => this.onSelected(activatedIndex)}
+                                        className="locations"
+                                    >
+                                        {reviewLocations.map(location => (
+                                            <ListItem title={res.panel.clicktoedit} key={location.id}>
+                                                <Comment
+                                                    comment={location.firstComment}
+                                                    isImportant={location.priority === Priority.Important}
+                                                    isDone={location.isDone}
+                                                />
+                                                <IconButton
+                                                    className="edit"
+                                                    title={res.panel.opendetails}
+                                                    onClick={e => this.onEditClick(e, location)}
+                                                >
+                                                    <MaterialIcon icon="edit" />
+                                                </IconButton>
+                                            </ListItem>
+                                        ))}
+                                    </List>
+                                </>
+                            )}
+                            {editedPinLocation && (
+                                <ReviewDetails
+                                    onCancel={() => (this.props.reviewStore.editedPinLocation = null)}
+                                    iframe={this.props.iframe}
+                                    currentEditLocation={this.props.reviewStore.editedPinLocation}
+                                />
+                            )}
+                        </div>
+                    </>
                 )}
             </>
         );


### PR DESCRIPTION
![list](https://user-images.githubusercontent.com/1321664/61404282-6fe19300-a8d7-11e9-9c6e-1232890d697e.gif)

* Show 'Go back to list' as icon in the pin-navigator
* Render Open/Close review panel buttons as icons sticked to the panel
on the left.

Closes #26