### PR TITLE
Render data-epi-property-name for all nodes

### DIFF
--- a/src/external-reviews/EditReview/PageEditPartialRouter.cs
+++ b/src/external-reviews/EditReview/PageEditPartialRouter.cs
@@ -51,6 +51,7 @@ namespace AdvancedExternalReviews.EditReview
                 segmentContext.RemainingPath = nextSegment.Remaining;
 
                 segmentContext.ContextMode = ContextMode.Edit;
+                segmentContext.RouteData.DataTokens[RoutingConstants.NodeKey] = page.ContentLink;
                 ExternalReview.IsInExternalReviewContext = true;
 
                 return page;


### PR DESCRIPTION
We have to add the nodeKey to routeData with our custom contentLink as
value. Without it it was always StartPage resolved as the
currentContentContext.Content in ContentPropertiesStack.

Closes #62