### PR TITLE
Fix sliding panel styling

### DIFF
--- a/src/ui/src/comment/comment.scss
+++ b/src/ui/src/comment/comment.scss
@@ -27,11 +27,15 @@
             font-size: 0.9rem;
             margin-right: 5px;
             float: left;
+            text-overflow: ellipsis;
+            width: 220px;
+            white-space: nowrap;
+            overflow: hidden;
         }
 
         .date {
             font-style: italic;
-            font-size: 0.9rem;
+            font-size: 0.7rem;
             color: #a0a0a0;
             float: left;
         }

--- a/src/ui/src/comment/comment.tsx
+++ b/src/ui/src/comment/comment.tsx
@@ -33,7 +33,9 @@ export default class Comment extends React.Component<CommentProps, any> {
                 <div className="message">
                     <div>
                         {this.props.isImportant && <MaterialIcon icon="priority_high" title={res.priority.important} />}
-                        <span className="author">{this.props.comment.author}</span>
+                        <span className="author" title={this.props.comment.author}>
+                            {this.props.comment.author}
+                        </span>
                         <span className="date" title={this.props.comment.formattedDate}>
                             {this.props.comment.userFriendlyDate}
                         </span>


### PR DESCRIPTION
We have to use text-overflow for usernames, they can be very long.
Additionally, just to save space we will reduce the size of the date
string as it's just an info text, not very important.

Closes #68