### PR TITLE
Node DataToken cannot be set to a draft version

### DIFF
--- a/src/external-reviews/AdvancedExternalReviews.csproj
+++ b/src/external-reviews/AdvancedExternalReviews.csproj
@@ -132,6 +132,7 @@
     </Reference>
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>
@@ -169,6 +170,8 @@
     <Compile Include="DraftContentAreaPreview\DraftContentAreaLoader.cs" />
     <Compile Include="DraftContentAreaPreview\DraftContentAreaRenderer.cs" />
     <Compile Include="EditReview\ConvertEditLinksFilter.cs" />
+    <Compile Include="EditReview\ExternalReviewFilterProvider.cs" />
+    <Compile Include="EditReview\ExternalReviewFilterInitialization.cs" />
     <Compile Include="EditReview\PropertyResolver.cs" />
     <Compile Include="ExternalReview.cs" />
     <Compile Include="ManageLinks\ExternalReviewLinksManageComponent.cs" />

--- a/src/external-reviews/EditReview/ExternalReviewFilterInitialization.cs
+++ b/src/external-reviews/EditReview/ExternalReviewFilterInitialization.cs
@@ -1,0 +1,30 @@
+using System.Linq;
+using System.Web.Mvc;
+using EPiServer.Framework;
+using EPiServer.Framework.Initialization;
+using EPiServer.ServiceLocation;
+
+namespace AdvancedExternalReviews.EditReview
+{
+    [InitializableModule]
+    [ModuleDependency(typeof(EPiServer.Web.InitializationModule))]
+    public class ExternalReviewFilterInitialization : IConfigurableModule
+    {
+        public void Initialize(InitializationEngine context)
+        {
+            var providers = FilterProviders.Providers.ToList();
+            FilterProviders.Providers.Clear();
+            FilterProviders.Providers.Add(new ExternalReviewFilterProvider(providers));
+        }
+
+        public void Uninitialize(InitializationEngine context)
+        {
+
+        }
+
+        public void ConfigureContainer(ServiceConfigurationContext context)
+        {
+
+        }
+    }
+}

--- a/src/external-reviews/EditReview/ExternalReviewFilterProvider.cs
+++ b/src/external-reviews/EditReview/ExternalReviewFilterProvider.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web.Mvc;
+using EPiServer.Web.Mvc;
+
+namespace AdvancedExternalReviews.EditReview
+{
+    public class ExternalReviewFilterProvider : IFilterProvider
+    {
+        private readonly FilterProviderCollection _filterProviders;
+        private readonly Type _authorizeContent = typeof(AuthorizeContentAttribute);
+
+        public ExternalReviewFilterProvider(IList<IFilterProvider> filters)
+        {
+            _filterProviders = new FilterProviderCollection(filters);
+        }
+
+        public IEnumerable<Filter> GetFilters(ControllerContext controllerContext,
+            ActionDescriptor actionDescriptor)
+        {
+            var filters = _filterProviders.GetFilters(controllerContext, actionDescriptor);
+            return ExternalReview.IsInExternalReviewContext ? filters.Where(x => x.Instance.GetType() != _authorizeContent) : filters;
+        }
+    }
+}


### PR DESCRIPTION
Node DataToken cannot be set to a draft version

Regression after #64. When setting the token to a draft version
it is not possible to render the page (access denied).
But the token is needed because otherwise it is always the StartPage
that is set in currentContentContext.Content in ContentPropertiesStack.
This fix will make sure that the Authorize filter will not be used when
the request is in external review context.

Closes #71
CLoses #74
Closes #53