### PR TITLE
Should not compare with projectId when it's null

### DIFF
--- a/src/external-reviews/ReviewLinksRepository/ExternalReviewLinksRepository.cs
+++ b/src/external-reviews/ReviewLinksRepository/ExternalReviewLinksRepository.cs
@@ -31,6 +31,12 @@ namespace AdvancedExternalReviews.ReviewLinksRepository
 
         public IEnumerable<ExternalReviewLink> GetLinksForContent(ContentReference contentLink, int? projectId)
         {
+            if (!projectId.HasValue)
+            {
+                // when project is null, then set it to -1
+                // to make sure that it won't return all links with no projects set
+                projectId = -1;
+            }
             return GetStore().Items<ExternalReviewLinkDds>().Where(x => x.ContentLink == contentLink || x.ProjectId == projectId).ToList().Select(
                 _externalReviewLinkBuilder.FromExternalReview);
         }


### PR DESCRIPTION
Steps o reproduce:
1. Have two pages with no links and no active project
2. Go to page 1 and create few links
3. Go to page 2

Expected: There are no links
Actual: All links from page 1 are on the list