### PR TITLE
Allow developer to disable the add-on

### DIFF
--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
@@ -15,6 +15,11 @@ define([
         initialize: function () {
             this.inherited(arguments);
 
+            var options = this._settings.options || {};
+            if (!options.isEnabled) {
+                return;
+            }
+
             var registry = this.resolveDependency("epi.storeregistry");
 
             //Register store

--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/module.config
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/module.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<module clientResourceRelativePath="1.0.0">
+<module clientResourceRelativePath="1.0.0"
+        type="AdvancedExternalReviews.AdvancedApprovalModule, AdvancedExternalReviews" >
 
   <assemblies>
     <add assembly="AdvancedExternalReviews" />

--- a/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/initializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/initializer.js
@@ -25,6 +25,11 @@ define([
         initialize: function () {
             this.inherited(arguments);
 
+            var options = this._settings.options || {};
+            if (!options.isEnabled) {
+                return;
+            }
+
             var registry = this.resolveDependency("epi.storeregistry");
 
             //Register store

--- a/src/alloy/modules/_protected/advanced-cms.Reviews/module.config
+++ b/src/alloy/modules/_protected/advanced-cms.Reviews/module.config
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<module clientResourceRelativePath="1.0.0">
+<module clientResourceRelativePath="1.0.0"
+        type="AdvancedExternalReviews.AdvancedReviewsModule, AdvancedExternalReviews">
 
   <assemblies>
     <add assembly="AdvancedApprovalReviews" />

--- a/src/external-reviews/BlocksPreview/BlocksTemplateCoordinator.cs
+++ b/src/external-reviews/BlocksPreview/BlocksTemplateCoordinator.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using EPiServer.Core;
 using EPiServer.Framework.Web;
+using EPiServer.ServiceLocation;
 using EPiServer.Web;
 
 namespace AdvancedExternalReviews.BlocksPreview
@@ -9,6 +10,12 @@ namespace AdvancedExternalReviews.BlocksPreview
     {
         public static void OnTemplateResolved(object sender, TemplateResolverEventArgs args)
         {
+            var options = ServiceLocator.Current.GetInstance<ExternalReviewOptions>();
+            if (!options.IsEnabled)
+            {
+                return;
+            }
+
             if (args.ItemToRender is BlockData)
             {
                 if (args.RequestedCategory == TemplateTypeCategories.MvcController ||

--- a/src/external-reviews/EditReview/GlobalRouteInitialization.cs
+++ b/src/external-reviews/EditReview/GlobalRouteInitialization.cs
@@ -28,6 +28,10 @@ namespace AdvancedExternalReviews.EditReview
         private void Global_RoutesRegistrating(object sender, EPiServer.Web.Routing.RouteRegistrationEventArgs e)
         {
             var externalReviewOptions = ServiceLocator.Current.GetInstance<ExternalReviewOptions>();
+            if (!externalReviewOptions.IsEnabled)
+            {
+                return;
+            }
 
             GlobalFilters.Filters.Add(new ConvertEditLinksFilter());
 

--- a/src/external-reviews/EditReview/PageEditPartialRouter.cs
+++ b/src/external-reviews/EditReview/PageEditPartialRouter.cs
@@ -28,6 +28,11 @@ namespace AdvancedExternalReviews.EditReview
 
         public object RoutePartial(PageData content, SegmentContext segmentContext)
         {
+            if (!_externalReviewOptions.IsEnabled)
+            {
+                return null;
+            }
+
             var nextSegment = segmentContext.GetNextValue(segmentContext.RemainingPath);
             if (nextSegment.Next != _externalReviewOptions.ContentIframeEditUrlSegment)
             {

--- a/src/external-reviews/ExternalReviewOptions.cs
+++ b/src/external-reviews/ExternalReviewOptions.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using AdvancedExternalReviews.Properties;
+using EPiServer.Framework.Web.Resources;
 using EPiServer.ServiceLocation;
+using EPiServer.Shell.Modules;
 
 namespace AdvancedExternalReviews
 {
@@ -9,6 +11,11 @@ namespace AdvancedExternalReviews
     public class ExternalReviewOptions
     {
         public string ReviewsUrl { get; set; } = "externalContentReviews";
+
+        /// <summary>
+        /// Gets or sets if the plugin should be initialized in Edit Mode
+        /// </summary>
+        public bool IsEnabled { get; set; } = true;
 
         /// <summary>
         /// URL used for displaying readonly version of page
@@ -102,5 +109,46 @@ namespace AdvancedExternalReviews
         /// PIN code length
         /// </summary>
         public int CodeLength { get; set; } = 4;
+    }
+
+    public class AdvancedReviewsModule : ShellModule
+    {
+        public AdvancedReviewsModule(string name, string routeBasePath, string resourceBasePath)
+            : base(name, routeBasePath, resourceBasePath)
+        {
+        }
+
+        /// <inheritdoc />
+        public override ModuleViewModel CreateViewModel(ModuleTable moduleTable, IClientResourceService clientResourceService)
+        {
+            var options = ServiceLocator.Current.GetInstance<ExternalReviewOptions>();
+            return new AdvancedReviewsModuleViewModel(this, clientResourceService, options);
+        }
+    }
+
+    public class AdvancedApprovalModule : ShellModule
+    {
+        public AdvancedApprovalModule(string name, string routeBasePath, string resourceBasePath)
+            : base(name, routeBasePath, resourceBasePath)
+        {
+        }
+
+        /// <inheritdoc />
+        public override ModuleViewModel CreateViewModel(ModuleTable moduleTable, IClientResourceService clientResourceService)
+        {
+            var options = ServiceLocator.Current.GetInstance<ExternalReviewOptions>();
+            return new AdvancedReviewsModuleViewModel(this, clientResourceService, options);
+        }
+    }
+
+    public class AdvancedReviewsModuleViewModel : ModuleViewModel
+    {
+        public AdvancedReviewsModuleViewModel(ShellModule shellModule, IClientResourceService clientResourceService, ExternalReviewOptions options) :
+            base(shellModule, clientResourceService)
+        {
+            Options = options;
+        }
+
+        public ExternalReviewOptions Options { get; }
     }
 }

--- a/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
+++ b/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
@@ -20,9 +20,8 @@ namespace AdvancedExternalReviews.ManageLinks
             : base("advanced-cms-external-review/external-review-manage-links-component")
         {
             _options = options;
-
-            this.LanguagePath = "/externalreviews/component";
-
+            IsAvailableForUserSelection = options.IsEnabled;
+            LanguagePath = "/externalreviews/component";
             Categories = new[] {"content"};
             SortOrder = 1000;
             PlugInAreas = new[]
@@ -40,6 +39,7 @@ namespace AdvancedExternalReviews.ManageLinks
                 base.Settings["editableLinksEnabled"] = _options.EditableLinksEnabled;
                 base.Settings["pinCodeSecurityEnabled"] = _options.PinCodeSecurity.Enabled;
                 base.Settings["pinCodeLength"] = _options.PinCodeSecurity.CodeLength;
+                base.Settings["isEnabled"] = _options.IsEnabled;
 
                 return base.Settings;
             }

--- a/src/external-reviews/PagePreviewPartialRouter.cs
+++ b/src/external-reviews/PagePreviewPartialRouter.cs
@@ -39,6 +39,11 @@ namespace AdvancedExternalReviews
 
         public object RoutePartial(PageData content, SegmentContext segmentContext)
         {
+            if (!_externalReviewOptions.IsEnabled)
+            {
+                return null;
+            }
+
             var nextSegment = segmentContext.GetNextValue(segmentContext.RemainingPath);
             if (string.IsNullOrWhiteSpace(nextSegment.Next))
             {

--- a/src/ui/src/external-reviews-manage-links/external-review-manage-links-widget.tsx
+++ b/src/ui/src/external-reviews-manage-links/external-review-manage-links-widget.tsx
@@ -13,6 +13,10 @@ import res from "epi/i18n!epi/cms/nls/externalreviews";
  */
 export default declare([WidgetBase, _ContentContextMixin], {
     postCreate: function() {
+        if (!this.params.isEnabled) {
+            return;
+        }
+
         this._reviewService = new ExternalReviewService();
 
         this.own(this._reviewService);
@@ -36,6 +40,10 @@ export default declare([WidgetBase, _ContentContextMixin], {
         );
     },
     contextChanged: function() {
+        if (!this.params.isEnabled) {
+            return;
+        }
+
         if (
             !this._currentContext ||
             (this._currentContext.type !== "epi.cms.project" && this._currentContext.type !== "epi.cms.contentdata")
@@ -46,6 +54,10 @@ export default declare([WidgetBase, _ContentContextMixin], {
         this.store.load();
     },
     destroy: function() {
+        if (!this.params.isEnabled) {
+            return;
+        }
+
         ReactDOM.unmountComponentAtNode(this.domNode);
     }
 });


### PR DESCRIPTION
We will disable:
* partial routers
* extra routes
* template coordinators
* manage links component will be empty
(user has to manually remove it if it was added before)
* the toggle button in edit mode

Closes #97