### PR TITLE
Set up resize and beforeunload events on the first render

### DIFF
--- a/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/onPageEditingInitializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/onPageEditingInitializer.js
@@ -48,6 +48,8 @@ define([
                 reviewWidget.placeAt(div);
                 var editLayoutContainer = document.getElementsByClassName("epi-editorViewport")[0];
                 editLayoutContainer.appendChild(div);
+            } else {
+                reviewWidget.loadPins();
             }
             toggleReviewOverlay(toggle);
         });

--- a/src/ui/src/iframe-with-pins/iframe-with-pins.tsx
+++ b/src/ui/src/iframe-with-pins/iframe-with-pins.tsx
@@ -55,6 +55,7 @@ export default class IframeWithPins extends React.Component<IframeWithPinsProps,
 
     componentDidMount() {
         this.props.iframe.addEventListener("load", this.loadIframe.bind(this));
+        this.loadIframe();
     }
 
     componentWillUnmount() {
@@ -99,10 +100,7 @@ export default class IframeWithPins extends React.Component<IframeWithPinsProps,
         const showReviewIntro: boolean =
             this.props.reviewStore.reviewLocations.length === 0 && localStorage.getItem("reviewIntro") !== "false";
 
-        const positionCalculator = new PositionCalculator(
-            this.state.documentSize,
-            this.props.iframe.contentDocument
-        );
+        const positionCalculator = new PositionCalculator(this.state.documentSize, this.props.iframe.contentDocument);
 
         return (
             <>

--- a/src/ui/src/review-component-widget/review-component-widget.tsx
+++ b/src/ui/src/review-component-widget/review-component-widget.tsx
@@ -4,20 +4,19 @@ import { Provider } from "mobx-react";
 import declare from "dojo/_base/declare";
 import WidgetBase from "dijit/_WidgetBase";
 import ApplicationSettings from "epi-cms/ApplicationSettings";
-import _ContentContextMixin from "epi-cms/_ContentContextMixin";
 import ReviewService from "advanced-cms-review/advancedReviewService";
 import IframeWithPins from "../iframe-with-pins/iframe-with-pins";
 import res from "epi/i18n!epi/cms/nls/reviewcomponent";
 
 import { createStores } from "../store/review-store";
 
-export default declare([WidgetBase, _ContentContextMixin], {
+export default declare([WidgetBase], {
     postCreate: function() {
         //TODO: async
         this._reviewService = new ReviewService();
         this.own(this._reviewService);
         this.stores = createStores(this._reviewService, res);
-        this.stores.reviewStore.load();
+        this.loadPins();
         this.stores.reviewStore.currentUser = ApplicationSettings.userName;
         this.stores.reviewStore.currentLocale = this.language;
         this.stores.reviewStore.propertyNameMapping = this.propertyNameMapping;
@@ -37,12 +36,7 @@ export default declare([WidgetBase, _ContentContextMixin], {
     updateDisplayNamesDictionary: function(propertyNameMapping: object) {
         this.stores.reviewStore.propertyNameMapping = propertyNameMapping;
     },
-
-    contextChanged: function() {
-        if (!this._currentContext || this._currentContext.type !== "epi.cms.contentdata") {
-            return;
-        }
-
+    loadPins: function() {
         this.stores.reviewStore.load();
     },
     destroy: function() {


### PR DESCRIPTION
Once the component is initialized for the first time, the
iframe is already there on the page.
The extra listener to the 'load' event is only to handle
scenario when clicking on the page tree and changing
context while the ReviewWidget instance has already been
created.
If the widget is already created then we will just
load new pins from the store.
ShowReviews is no longer a toggle button, we always reset it
to false after every context change so there is no point
in having two contextchanged event handlers.