### PR TITLE
Fix positioning of the pins

### DIFF
--- a/src/ui/src/editable-external-reviews/editable-external-review-component.tsx
+++ b/src/ui/src/editable-external-reviews/editable-external-review-component.tsx
@@ -106,7 +106,7 @@ function EditableExternalReviewComponent({ iframe }: EditableExternalReviewProps
                 <ConfirmNameDialog open={true} initialUserName={userName} onClose={setUserName} />
             ) : (
                 <Provider {...stores}>
-                    <IframeWithPins iframe={iframe} />
+                    <IframeWithPins iframe={iframe} external />
                 </Provider>
             )}
         </>

--- a/src/ui/src/iframe-overlay/iframe-overlay.tsx
+++ b/src/ui/src/iframe-overlay/iframe-overlay.tsx
@@ -7,6 +7,8 @@ import offset from "../position-calculator/offset";
 interface IframeOverlayProps {
     iframe: HTMLIFrameElement;
     reviewStore?: IReviewComponentStore;
+    external: boolean;
+
     reviewLocationCreated(location: PinLocation): void;
 }
 
@@ -89,10 +91,16 @@ export default class IframeOverlay extends React.Component<IframeOverlayProps, a
 
         const generator = new CssSelectorGenerator();
 
-        const clickedElement = this.props.iframe.contentDocument.elementFromPoint(e.offsetX, e.offsetY) as HTMLElement;
+        let point: { x: number; y: number };
+        if (this.props.external) {
+            point = { x: e.pageX, y: e.pageY };
+        } else {
+            point = { x: e.offsetX, y: e.offsetY };
+        }
+        const clickedElement = this.props.iframe.contentDocument.elementFromPoint(point.x, point.y) as HTMLElement;
         const selector = generator.getSelector(clickedElement);
 
-        const nodeOffset = offset(clickedElement, this.props.iframe.contentDocument);
+        const nodeOffset = offset(clickedElement, this.props.external);
 
         let reviewLocation = new PinLocation(this.props.reviewStore, {
             documentRelativePosition: {

--- a/src/ui/src/iframe-with-pins/iframe-with-pins.tsx
+++ b/src/ui/src/iframe-with-pins/iframe-with-pins.tsx
@@ -18,6 +18,7 @@ interface IframeState {
 interface IframeWithPinsProps {
     iframe: HTMLIFrameElement;
     reviewStore?: IReviewComponentStore;
+    external?: boolean;
 }
 
 @inject("reviewStore")
@@ -100,7 +101,11 @@ export default class IframeWithPins extends React.Component<IframeWithPinsProps,
         const showReviewIntro: boolean =
             this.props.reviewStore.reviewLocations.length === 0 && localStorage.getItem("reviewIntro") !== "false";
 
-        const positionCalculator = new PositionCalculator(this.state.documentSize, this.props.iframe.contentDocument);
+        const positionCalculator = new PositionCalculator(
+            this.state.documentSize,
+            this.props.external,
+            this.props.iframe.contentDocument
+        );
 
         return (
             <>
@@ -108,6 +113,7 @@ export default class IframeWithPins extends React.Component<IframeWithPinsProps,
                     <IframeOverlay
                         iframe={this.props.iframe}
                         reviewLocationCreated={location => this.setState({ newLocation: location })}
+                        external={this.props.external}
                     >
                         <PinCollection newLocation={this.state.newLocation} positionCalculator={positionCalculator} />
                         {showReviewIntro && (

--- a/src/ui/src/position-calculator/offset.ts
+++ b/src/ui/src/position-calculator/offset.ts
@@ -1,8 +1,16 @@
-export default function(node: HTMLElement, doc: HTMLDocument) {
+export default function(node: HTMLElement, external: boolean) {
     const rect = node.getBoundingClientRect();
 
+    // In external edit scenario we need to add scrolling positions as the bounding rect is viewport-specific
+    // However, in edit mode the iframe is inside .epi-editorViewport and the bounding rect does include the scroll position so there
+    // is no need to add anything
+    let domOffset: { x: number; y: number } = { x: 0, y: 0 };
+    if (external) {
+        domOffset = { x: node.ownerDocument.defaultView.pageXOffset, y: node.ownerDocument.defaultView.pageYOffset };
+    }
+
     return {
-        top: rect.top + doc.body.scrollTop,
-        left: rect.left + doc.body.scrollLeft
+        top: rect.top + domOffset.y,
+        left: rect.left + domOffset.x
     };
 }

--- a/src/ui/src/position-calculator/position-calculator.test.ts
+++ b/src/ui/src/position-calculator/position-calculator.test.ts
@@ -20,7 +20,7 @@ describe("when property position data is not available", () => {
     describe("and the document size is the same as the saved one", () => {
         beforeEach(() => {
             pin = getPin();
-            positionCalculator = new PositionCalculator(originalDocumentLocation);
+            positionCalculator = new PositionCalculator(originalDocumentLocation, false);
         });
 
         test("it should return original position", () => {
@@ -33,7 +33,7 @@ describe("when property position data is not available", () => {
         beforeEach(() => {
             pin = getPin();
             const newDocumentSize: Dimensions = { x: 1200, y: 600 };
-            positionCalculator = new PositionCalculator(newDocumentSize);
+            positionCalculator = new PositionCalculator(newDocumentSize, false);
         });
 
         test("it should return rescaled position relative to the new document size", () => {

--- a/src/ui/src/position-calculator/position-calculator.ts
+++ b/src/ui/src/position-calculator/position-calculator.ts
@@ -3,10 +3,12 @@ import offset from "./offset";
 
 export default class PositionCalculator {
     private readonly _documentSize: Dimensions;
+    private readonly _external: boolean;
     private readonly _document: Document;
 
-    constructor(documentSize: Dimensions, document?: Document) {
+    constructor(documentSize: Dimensions, external: boolean, document?: Document) {
         this._documentSize = documentSize;
+        this._external = external;
         this._document = document;
     }
 
@@ -16,7 +18,7 @@ export default class PositionCalculator {
         nodePosition: Dimensions,
         nodeSize: Dimensions
     ) {
-        const nodeOffset = offset(node, this._document);
+        const nodeOffset = offset(node, this._external);
 
         const originalOffsetFromLeft = documentRelativeOffset.x - nodePosition.x;
         const originalOffsetFromTop = documentRelativeOffset.y - nodePosition.y;
@@ -45,7 +47,19 @@ export default class PositionCalculator {
 
     calculate(location: PinPositioningDetails): Dimensions {
         if (this._document) {
-            if (location.propertyName && location.propertyPosition && location.propertySize) {
+            if (location.clickedDomNodeSelector && location.clickedDomNodePosition && location.clickedDomNodeSize) {
+                const node: HTMLElement = this._document.querySelector(location.clickedDomNodeSelector);
+                if (!node) {
+                    return this.resize(location);
+                }
+
+                return this.positionDomNode(
+                    node,
+                    location.documentRelativePosition,
+                    location.clickedDomNodePosition,
+                    location.clickedDomNodeSize
+                );
+            } else if (location.propertyName && location.propertyPosition && location.propertySize) {
                 const node: HTMLElement = this._document.querySelector(
                     `[data-epi-property-name='${location.propertyName}']`
                 );
@@ -57,22 +71,6 @@ export default class PositionCalculator {
                     location.documentRelativePosition,
                     location.propertyPosition,
                     location.propertySize
-                );
-            } else if (
-                location.clickedDomNodeSelector &&
-                location.clickedDomNodePosition &&
-                location.clickedDomNodeSize
-            ) {
-                const node: HTMLElement = this._document.querySelector(location.clickedDomNodeSelector);
-                if (!node) {
-                    return this.resize(location);
-                }
-
-                return this.positionDomNode(
-                    node,
-                    location.documentRelativePosition,
-                    location.clickedDomNodePosition,
-                    location.clickedDomNodeSize
                 );
             }
         }


### PR DESCRIPTION
It works differently in Edit Mode where the iframe is
embedded in a epi-viewport div and in external view
where it takes the whole body and uses browser's window
scroll.
For external pins we need to save and load the pins
always with the defaultView scrolling element offsets.

Closes #104