### PR TITLE
Resolve url explicitly

### DIFF
--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/PagePreview/Index.cshtml
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/PagePreview/Index.cshtml
@@ -36,7 +36,7 @@
                 line-height: 14px;
             }
         </style>
-    </head><body style="width: 100%; height: 100%; font-size: 0"><div id="reviews-editor" data-url="./AddPin" data-user="@HttpContext.Current.User.Identity.Name" data-metadata="@Model.Metadata" data-pins="@Model.ReviewPins"></div>
+    </head><body style="width: 100%; height: 100%; font-size: 0"><div id="reviews-editor" data-url="@Model.AddPinUrl" data-user="@HttpContext.Current.User.Identity.Name" data-metadata="@Model.Metadata" data-pins="@Model.ReviewPins"></div>
         <iframe id="editableIframe" src="@Model.EditableContentUrlSegment" width="100%" height="100%"></iframe>
 
         <script type="text/javascript">

--- a/src/external-reviews/EditReview/PageEditController.cs
+++ b/src/external-reviews/EditReview/PageEditController.cs
@@ -66,6 +66,7 @@ namespace AdvancedExternalReviews.EditReview
                     Name = content.Name,
                     EditableContentUrlSegment =
                         $"{startPageUrl}{_externalReviewOptions.ContentIframeEditUrlSegment}/{token}",
+                    AddPinUrl = $"{UrlPath.EnsureStartsWithSlash(_externalReviewOptions.ReviewsUrl)}/AddPin",
                     ReviewJsScriptPath = GetJsScriptPath(),
                     ResetCssPath = GetResetCssPath(),
                     ReviewPins = serializer.Serialize(_approvalReviewsRepository.Load(externalReviewLink.ContentLink)),
@@ -223,6 +224,11 @@ namespace AdvancedExternalReviews.EditReview
         /// Url used by the iframe, it contains specific language branch in which the content was created
         /// </summary>
         public string EditableContentUrlSegment { get; set; }
+
+        /// <summary>
+        /// Url where new pins will be posted to
+        /// </summary>
+        public string AddPinUrl { get; set; }
 
         public string ReviewJsScriptPath { get; set; }
         public string ResetCssPath { get; set; }


### PR DESCRIPTION
In order to always resolve the action url in the same way we will
create it explicitly rather than using "./" relative url which
did not resolve correctly with a trailing slash in the main
'external' url.

Closes #114