### PR TITLE
Inherit from the abstract ContentLoader

### DIFF
--- a/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
+++ b/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
@@ -1,4 +1,5 @@
 ﻿using EPiServer;
+using EPiServer.Core.Internal;
 using EPiServer.Framework;
 using EPiServer.Framework.Initialization;
 using EPiServer.ServiceLocation;
@@ -29,6 +30,17 @@ namespace AdvancedExternalReviews.DraftContentAreaPreview
                         locator.GetInstance<IPermanentLinkMapper>()));
 
             context.Services.Intercept<IContentLoader>(
+                (locator, defaultContentLoader) =>
+                {
+                    if (!locator.GetInstance<ExternalReviewOptions>().ContentReplacement.ReplaceChildren)
+                    {
+                        return defaultContentLoader;
+                    }
+
+                    return new DraftContentLoader(defaultContentLoader, locator.GetInstance<ServiceAccessor<ReviewsContentLoader>>());
+                });
+
+            context.Services.Intercept<ContentLoader>(
                 (locator, defaultContentLoader) =>
                 {
                     if (!locator.GetInstance<ExternalReviewOptions>().ContentReplacement.ReplaceChildren)

--- a/src/external-reviews/DraftContentLoader.cs
+++ b/src/external-reviews/DraftContentLoader.cs
@@ -5,11 +5,12 @@ using System.Linq;
 using AdvancedExternalReviews.DraftContentAreaPreview;
 using EPiServer;
 using EPiServer.Core;
+using EPiServer.Core.Internal;
 using EPiServer.ServiceLocation;
 
 namespace AdvancedExternalReviews
 {
-    public class DraftContentLoader : IContentLoader
+    public class DraftContentLoader : ContentLoader
     {
         private readonly IContentLoader _defaultContentLoader;
         private readonly ServiceAccessor<ReviewsContentLoader> _reviewsContentLoader;
@@ -20,37 +21,37 @@ namespace AdvancedExternalReviews
             _reviewsContentLoader = reviewsContentLoader;
         }
 
-        public T Get<T>(Guid contentGuid) where T : IContentData
+        public override T Get<T>(Guid contentGuid)
         {
             return _defaultContentLoader.Get<T>(contentGuid);
         }
 
-        public T Get<T>(Guid contentGuid, LoaderOptions settings) where T : IContentData
+        public override T Get<T>(Guid contentGuid, LoaderOptions settings)
         {
             return _defaultContentLoader.Get<T>(contentGuid, settings);
         }
 
-        public T Get<T>(Guid contentGuid, CultureInfo language) where T : IContentData
+        public override T Get<T>(Guid contentGuid, CultureInfo language)
         {
             return _defaultContentLoader.Get<T>(contentGuid, language);
         }
 
-        public T Get<T>(ContentReference contentLink) where T : IContentData
+        public override T Get<T>(ContentReference contentLink)
         {
             return _defaultContentLoader.Get<T>(contentLink);
         }
 
-        public T Get<T>(ContentReference contentLink, CultureInfo language) where T : IContentData
+        public override T Get<T>(ContentReference contentLink, CultureInfo language)
         {
             return _defaultContentLoader.Get<T>(contentLink, language);
         }
 
-        public T Get<T>(ContentReference contentLink, LoaderOptions settings) where T : IContentData
+        public override T Get<T>(ContentReference contentLink, LoaderOptions settings)
         {
             return _defaultContentLoader.Get<T>(contentLink, settings);
         }
 
-        public IEnumerable<T> GetChildren<T>(ContentReference contentLink) where T : IContentData
+        public override IEnumerable<T> GetChildren<T>(ContentReference contentLink)
         {
             if (!ExternalReview.IsInExternalReviewContext)
             {
@@ -60,7 +61,7 @@ namespace AdvancedExternalReviews
             return _reviewsContentLoader().GetChildrenWithReviews<T>(contentLink).ToList();
         }
 
-        public IEnumerable<T> GetChildren<T>(ContentReference contentLink, CultureInfo language) where T : IContentData
+        public override IEnumerable<T> GetChildren<T>(ContentReference contentLink, CultureInfo language)
         {
             if (!ExternalReview.IsInExternalReviewContext)
             {
@@ -70,7 +71,7 @@ namespace AdvancedExternalReviews
             return _reviewsContentLoader().GetChildrenWithReviews<T>(contentLink, language);
         }
 
-        public IEnumerable<T> GetChildren<T>(ContentReference contentLink, LoaderOptions settings) where T : IContentData
+        public override IEnumerable<T> GetChildren<T>(ContentReference contentLink, LoaderOptions settings)
         {
             if (!ExternalReview.IsInExternalReviewContext)
             {
@@ -80,7 +81,7 @@ namespace AdvancedExternalReviews
             return _reviewsContentLoader().GetChildrenWithReviews<T>(contentLink, settings);
         }
 
-        public IEnumerable<T> GetChildren<T>(ContentReference contentLink, CultureInfo language, int startIndex, int maxRows) where T : IContentData
+        public override IEnumerable<T> GetChildren<T>(ContentReference contentLink, CultureInfo language, int startIndex, int maxRows)
         {
             if (!ExternalReview.IsInExternalReviewContext)
             {
@@ -90,7 +91,7 @@ namespace AdvancedExternalReviews
             return _reviewsContentLoader().GetChildrenWithReviews<T>(contentLink, language, startIndex, maxRows);
         }
 
-        public IEnumerable<T> GetChildren<T>(ContentReference contentLink, LoaderOptions settings, int startIndex, int maxRows) where T : IContentData
+        public override IEnumerable<T> GetChildren<T>(ContentReference contentLink, LoaderOptions settings, int startIndex, int maxRows)
         {
             if (!ExternalReview.IsInExternalReviewContext)
             {
@@ -100,62 +101,62 @@ namespace AdvancedExternalReviews
             return _reviewsContentLoader().GetChildrenWithReviews<T>(contentLink, settings, startIndex, maxRows);
         }
 
-        public IEnumerable<ContentReference> GetDescendents(ContentReference contentLink)
+        public override IEnumerable<ContentReference> GetDescendents(ContentReference contentLink)
         {
             return _defaultContentLoader.GetDescendents(contentLink);
         }
 
-        public IEnumerable<IContent> GetAncestors(ContentReference contentLink)
+        public override IEnumerable<IContent> GetAncestors(ContentReference contentLink)
         {
             return _defaultContentLoader.GetAncestors(contentLink);
         }
 
-        public IEnumerable<IContent> GetItems(IEnumerable<ContentReference> contentLinks, CultureInfo language)
+        public override IEnumerable<IContent> GetItems(IEnumerable<ContentReference> contentLinks, CultureInfo language)
         {
             return _defaultContentLoader.GetItems(contentLinks, language);
         }
 
-        public IEnumerable<IContent> GetItems(IEnumerable<ContentReference> contentLinks, LoaderOptions settings)
+        public override IEnumerable<IContent> GetItems(IEnumerable<ContentReference> contentLinks, LoaderOptions settings)
         {
             return _defaultContentLoader.GetItems(contentLinks, settings);
         }
 
-        public IContent GetBySegment(ContentReference parentLink, string urlSegment, CultureInfo language)
+        public override IContent GetBySegment(ContentReference parentLink, string urlSegment, CultureInfo language)
         {
             return _defaultContentLoader.GetBySegment(parentLink, urlSegment, language);
         }
 
-        public IContent GetBySegment(ContentReference parentLink, string urlSegment, LoaderOptions settings)
+        public override IContent GetBySegment(ContentReference parentLink, string urlSegment, LoaderOptions settings)
         {
             return _defaultContentLoader.GetBySegment(parentLink, urlSegment, settings);
         }
 
-        public bool TryGet<T>(ContentReference contentLink, out T content) where T : IContentData
+        public override bool TryGet<T>(ContentReference contentLink, out T content)
         {
             return _defaultContentLoader.TryGet(contentLink, out content);
         }
 
-        public bool TryGet<T>(ContentReference contentLink, CultureInfo language, out T content) where T : IContentData
+        public override bool TryGet<T>(ContentReference contentLink, CultureInfo language, out T content)
         {
             return _defaultContentLoader.TryGet(contentLink, language, out content);
         }
 
-        public bool TryGet<T>(ContentReference contentLink, LoaderOptions settings, out T content) where T : IContentData
+        public override bool TryGet<T>(ContentReference contentLink, LoaderOptions settings, out T content)
         {
             return _defaultContentLoader.TryGet(contentLink, settings, out content);
         }
 
-        public bool TryGet<T>(Guid contentGuid, out T content) where T : IContentData
+        public override bool TryGet<T>(Guid contentGuid, out T content)
         {
             return _defaultContentLoader.TryGet(contentGuid, out content);
         }
 
-        public bool TryGet<T>(Guid contentGuid, CultureInfo language, out T content) where T : IContentData
+        public override bool TryGet<T>(Guid contentGuid, CultureInfo language, out T content)
         {
             return _defaultContentLoader.TryGet(contentGuid, language, out content);
         }
 
-        public bool TryGet<T>(Guid contentGuid, LoaderOptions loaderOptions, out T content) where T : IContentData
+        public override bool TryGet<T>(Guid contentGuid, LoaderOptions loaderOptions, out T content)
         {
             return _defaultContentLoader.TryGet(contentGuid, loaderOptions, out content);
         }


### PR DESCRIPTION
In order to make the obsolete DataFactory.Instance to work
we need to additionally intercept ContentLoader calls as
DataFactory uses that internal type instead of the interface.

Closes #133