### PR TITLE
Prevent caching GET requests to review stores

### DIFF
--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
@@ -26,6 +26,7 @@ define([
             registry.add("externalreviews",
                 new Throttle(
                     new JsonRest({
+                        preventCache: true,
                         target: this._getRestPath("externalreviewstore")//,
                         //idProperty: "contentLink"
                     })

--- a/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/initializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.Reviews/1.0.0/Scripts/initializer.js
@@ -38,6 +38,7 @@ define([
             registry.add("approvaladvancedreview",
                 new Throttle(
                     new JsonRest({
+                        preventCache: true,
                         target: this._getRestPath("approvaladvancedreview")//,
                         //idProperty: "contentLink"
                     })
@@ -46,6 +47,7 @@ define([
             registry.add("approvallanguage",
                 new Throttle(
                     new JsonRest({
+                        preventCache: true,
                         target: this._getRestPath("approvallanguage")//,
                         //idProperty: "contentLink"
                     })


### PR DESCRIPTION
IE11 ignores cache-control request header so we need
to use the preventDefault query param to make sure the
browser does not cache anything.
https://stackoverflow.com/questions/40591036/ie-11-ignoring-cache-control-header-in-response