### PR TITLE
Make ContentArea.FilteredItems return unpublished content items

### DIFF
--- a/src/external-reviews/AdvancedExternalReviews.csproj
+++ b/src/external-reviews/AdvancedExternalReviews.csproj
@@ -182,6 +182,7 @@
     <Compile Include="BlocksPreview\BlockPreviewViewModel.cs" />
     <Compile Include="BlocksPreview\BlocksTemplateCoordinator.cs" />
     <Compile Include="CustomContentLoaderInitialization.cs" />
+    <Compile Include="DraftContentAreaPreview\PublishedStateAssessorDecorator.cs" />
     <Compile Include="DraftContentAreaPreview\ReviewsContentLoader.cs" />
     <Compile Include="DraftContentLoader.cs" />
     <Compile Include="PinCodeSecurity\ExternalLinkPinCodeSecurityHandler.cs" />

--- a/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
+++ b/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
@@ -1,7 +1,9 @@
 ﻿using EPiServer;
+using EPiServer.Core;
 using EPiServer.Core.Internal;
 using EPiServer.Framework;
 using EPiServer.Framework.Initialization;
+using EPiServer.Globalization;
 using EPiServer.ServiceLocation;
 using EPiServer.Web;
 using EPiServer.Web.Mvc.Html;
@@ -39,6 +41,11 @@ namespace AdvancedExternalReviews.DraftContentAreaPreview
 
                     return new DraftContentLoader(defaultContentLoader, locator.GetInstance<ServiceAccessor<ReviewsContentLoader>>());
                 });
+
+            context.Services.Intercept<IPublishedStateAssessor>(
+                (locator, defaultPublishedStateAssessor) =>
+                    new PublishedStateAssessorDecorator(defaultPublishedStateAssessor,
+                        locator.GetInstance<LanguageResolver>()));
 
             context.Services.Intercept<ContentLoader>(
                 (locator, defaultContentLoader) =>

--- a/src/external-reviews/DraftContentAreaPreview/PublishedStateAssessorDecorator.cs
+++ b/src/external-reviews/DraftContentAreaPreview/PublishedStateAssessorDecorator.cs
@@ -1,0 +1,31 @@
+using EPiServer.Core;
+using EPiServer.Globalization;
+
+namespace AdvancedExternalReviews.DraftContentAreaPreview
+{
+    public class PublishedStateAssessorDecorator : IPublishedStateAssessor
+    {
+        private readonly IPublishedStateAssessor _defaultService;
+        private readonly LanguageResolver _languageResolver;
+
+        public PublishedStateAssessorDecorator(IPublishedStateAssessor defaultService, LanguageResolver languageResolver)
+        {
+            _defaultService = defaultService;
+            _languageResolver = languageResolver;
+        }
+
+        public bool IsPublished(IContent content, PublishedStateCondition condition)
+        {
+            if (ExternalReview.IsInExternalReviewContext && ExternalReview.CustomLoaded.Contains(content.ContentLink.ToString()))
+            {
+                var cachedContent = ExternalReview.GetCachedContent(_languageResolver.GetPreferredCulture(), content.ContentLink);
+                if (cachedContent != null)
+                {
+                    return true;
+                }
+            }
+
+            return _defaultService.IsPublished(content, condition);
+        }
+    }
+}


### PR DESCRIPTION
We need a custom PublishedStateAssessorDecorator to behave differently
when in draft preview mode.