### PR TITLE
Handle urls with querystring params

### DIFF
--- a/src/alloy/Models/Pages/StartPage.cs
+++ b/src/alloy/Models/Pages/StartPage.cs
@@ -54,6 +54,9 @@ namespace AlloyTemplates.Models.Pages
         public virtual PageReference ContactsPageLink { get; set; }
 
         [Display(GroupName = Global.GroupNames.SiteSettings)]
+        public virtual Url FooBar { get; set; }
+
+        [Display(GroupName = Global.GroupNames.SiteSettings)]
         public virtual PageReference SearchPageLink { get; set; }
 
         [Display(GroupName = Global.GroupNames.SiteSettings)]

--- a/src/alloy/Views/StartPage/Index.cshtml
+++ b/src/alloy/Views/StartPage/Index.cshtml
@@ -29,3 +29,8 @@
 <br />
 <div>Url.ContentUrl(Model.CurrentPage.LinkURL)</div>
 <a href="@Url.ContentUrl(Model.CurrentPage.LinkURL)">Link (should be project specific)</a>
+<br />
+<br />
+<div>Url.ContentUrl(Model.CurrentPage.FooBar)</div>
+<a href="@Url.ContentUrl(Model.CurrentPage.FooBar)">Url (with querystring)</a>
+

--- a/src/external-reviews/PreviewUrlResolver.cs
+++ b/src/external-reviews/PreviewUrlResolver.cs
@@ -86,7 +86,11 @@ namespace AdvancedExternalReviews
 
         private string AppendGeneratedPostfix(string url)
         {
-            return $"{url.TrimEnd('/')}/{_externalReviewOptions.Service.ContentPreviewUrl}/{ExternalReview.Token}?{PreviewGenerated}=true";
+            var urlBuilder = new UrlBuilder(url);
+            urlBuilder.Path = string.Join("/", urlBuilder.Path.TrimEnd('/'),
+                _externalReviewOptions.Service.ContentPreviewUrl, ExternalReview.Token);
+            urlBuilder.QueryCollection.Add(PreviewGenerated, bool.TrueString);
+            return urlBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
We should parse the url via UrlBuilder and just append
a project query string param.
Additionally ContentPreviewUrl and token should be appended
to Path only.

#143