### PR TITLE
Pass the username in query string rather than parth of path

### DIFF
--- a/src/approval-reviews/AvatarsService/AvatarRouteExtensions.cs
+++ b/src/approval-reviews/AvatarsService/AvatarRouteExtensions.cs
@@ -6,8 +6,8 @@ namespace AdvancedApprovalReviews.AvatarsService
     {
         public static void RegisterReviewAvatarsRoute(this RouteCollection routes)
         {
-            var route = new Route("review-avatars/{userName}.jpg", new AvatarRouteRouteHandler());
-            string[] allowedMethods = { "GET", "POST" };
+            var route = new Route("review-avatars/get", new AvatarRouteRouteHandler());
+            string[] allowedMethods = { "GET" };
             var methodConstraints = new HttpMethodConstraint(allowedMethods);
             route.Constraints = new RouteValueDictionary { { "httpMethod", methodConstraints } };
             routes.Add(route);

--- a/src/approval-reviews/AvatarsService/ReviewAvatarsHandler.cs
+++ b/src/approval-reviews/AvatarsService/ReviewAvatarsHandler.cs
@@ -28,13 +28,14 @@ namespace AdvancedApprovalReviews.AvatarsService
         //TODO: try to use EPiServer.Web.MediaHandlerBase to turn on caching
         public void ProcessRequest(HttpContext context)
         {
-            var userName = context.Request.RequestContext.RouteData.Values["userName"] as string;
+            var userName = context.Request.QueryString.Get("userName");
             if (string.IsNullOrWhiteSpace(userName))
             {
                 context.Response.StatusCode = 404;
                 return;
             }
 
+            userName = HttpUtility.UrlDecode(userName);
             using (var memoryStream = new MemoryStream())
             {
                 var customAvatar = _customAvatarResolver.GetImage(userName);
@@ -49,12 +50,12 @@ namespace AdvancedApprovalReviews.AvatarsService
                     var encParams = new EncoderParameters { Param = new[] { new EncoderParameter(Encoder.Quality, 90L) } };
                     identicon.Save(memoryStream, encoder, encParams);
                 }
-                
+
                 var bytesInStream = memoryStream.ToArray();
 
                 context.Response.Clear();
                 context.Response.ContentType = "Image/jpeg";
-                
+
                 context.Response.BinaryWrite(bytesInStream);
 
                 // context.Response.End() affects the cache

--- a/src/ui/src/store/review-store.tsx
+++ b/src/ui/src/store/review-store.tsx
@@ -417,7 +417,8 @@ class ReviewComponentStore implements IReviewComponentStore {
     }
 
     @action getUserAvatarUrl(userName: string): string {
-        return `/review-avatars/${userName}.jpg`;
+        const encodedUserName = encodeURIComponent(userName);
+        return `/review-avatars/get?userName=${encodedUserName}`;
     }
 
     private saveLocation(reviewLocation: PinLocation): Promise<PinLocation> {


### PR DESCRIPTION
For AD logins like 'domain\username' asp.net goes crazy.
It's not possible to encode/decode since it's part of
the path. The only way is to use query string and default
urlencode/urldecode.

Closes #149