### PR TITLE
Do not calculate the height of context menu

### DIFF
--- a/src/ui/src/common/drop-down-menu.scss
+++ b/src/ui/src/common/drop-down-menu.scss
@@ -1,3 +1,7 @@
 .menu-button {
     cursor: pointer;
 }
+
+.epi-context-menu {
+    max-height: none !important; //TODO: Remove this hack until UI framework is upgraded
+}


### PR DESCRIPTION
"mdc-list-item" class in the new 11.28.0 UI package
has been changed from height 48px to 32px and the
surface contents do not fit.
For now let's just disable inline height for the
surface elements since we always show either
2 (manage links) or 3 (priority) items in the surface
component.
UIF 0.11.2 does not have that problem any more so
this commit should be reverted after UIF upgrade.

Closes #146