### PR TITLE
Rewrite the virtual path with the original URL segment

### DIFF
--- a/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
+++ b/src/external-reviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
@@ -29,7 +29,7 @@ namespace AdvancedExternalReviews.DraftContentAreaPreview
             context.Services.Intercept<UrlResolver>(
                 (locator, defaultUrlResolver) =>
                     new PreviewUrlResolver(defaultUrlResolver, locator.GetInstance<IContentLoader>(),
-                        locator.GetInstance<IPermanentLinkMapper>()));
+                        locator.GetInstance<IPermanentLinkMapper>(), locator.GetInstance<IContentProviderManager>()));
 
             context.Services.Intercept<IContentLoader>(
                 (locator, defaultContentLoader) =>


### PR DESCRIPTION
If editor changed the URLSegment then we have to use the original from
the published version. Otherwise we would get into 404s.

Closes #156