### PR TITLE
Bugfix/162 site url resolver

### DIFF
--- a/src/approval-reviews/SiteUriResolver.cs
+++ b/src/approval-reviews/SiteUriResolver.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using EPiServer.Core;
+using EPiServer.ServiceLocation;
+using EPiServer.Web;
+
+namespace AdvancedApprovalReviews
+{
+    public interface ISiteUriResolver
+    {
+        Uri GetUri(ContentReference contentReference);
+    }
+
+    [ServiceConfiguration(typeof(ISiteUriResolver))]
+    public class SiteUriResolver : ISiteUriResolver
+    {
+        public Uri GetUri(ContentReference contentReference)
+        {
+            return SiteDefinition.Current.SiteUrl;
+        }
+    }
+}

--- a/src/approval-reviews/StartPageResolver.cs
+++ b/src/approval-reviews/StartPageResolver.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using EPiServer;
-using EPiServer.Core;
+﻿using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using EPiServer.Web;
 using EPiServer.Web.Routing;
@@ -18,30 +14,18 @@ namespace AdvancedApprovalReviews
     public class StartPageUrlResolver: IStartPageUrlResolver
     {
         private readonly UrlResolver _urlResolver;
-        private readonly IContentLoader _contentLoader;
-        private readonly Lazy<IEnumerable<ContentReference>> _startPages;
+        private readonly ISiteDefinitionResolver _siteDefinitionResolver;
 
-        public StartPageUrlResolver(ISiteDefinitionRepository siteDefinitionRepository, UrlResolver urlResolver, IContentLoader contentLoader)
+        public StartPageUrlResolver(UrlResolver urlResolver, ISiteDefinitionResolver siteDefinitionResolver)
         {
             _urlResolver = urlResolver;
-            _contentLoader = contentLoader;
-            _startPages = new Lazy<IEnumerable<ContentReference>>(() =>
-            {
-                return siteDefinitionRepository.List().Select(x => x.StartPage.ToReferenceWithoutVersion());
-            });
+            _siteDefinitionResolver = siteDefinitionResolver;
         }
 
         public string GetUrl(ContentReference contentReference)
         {
-            var startPage = _startPages.Value.FirstOrDefault(x => x == contentReference.ToReferenceWithoutVersion());
-            if (startPage != null)
-            {
-                return _urlResolver.GetUrl(startPage);
-            }
-            var ancestorLinks = _contentLoader.GetAncestors(contentReference)
-                .Select(x => x.ContentLink.ToReferenceWithoutVersion());
-            startPage = _startPages.Value.FirstOrDefault(x => ancestorLinks.Contains(x));
-            return _urlResolver.GetUrl(startPage ?? ContentReference.StartPage);
+            var site = _siteDefinitionResolver.GetByContent(contentReference, true);
+            return _urlResolver.GetUrl(site?.StartPage ?? ContentReference.StartPage);
         }
     }
 }

--- a/src/external-reviews/ReviewLinksRepository/ExternalReviewStore.cs
+++ b/src/external-reviews/ReviewLinksRepository/ExternalReviewStore.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using System.Web.Mvc;
+using AdvancedApprovalReviews;
 using AdvancedExternalReviews.PinCodeSecurity;
 using EPiServer;
 using EPiServer.Cms.Shell.UI.Rest.Projects;
@@ -11,7 +12,6 @@ using EPiServer.Core;
 using EPiServer.Notification;
 using EPiServer.Notification.Internal;
 using EPiServer.Shell.Services.Rest;
-using EPiServer.Web;
 
 namespace AdvancedExternalReviews.ReviewLinksRepository
 {
@@ -27,11 +27,13 @@ namespace AdvancedExternalReviews.ReviewLinksRepository
         private readonly EmailNotificationProvider _emailNotificationProvider;
         private readonly ExternalReviewOptions _externalReviewOptions;
         private readonly CurrentProject _currentProject;
+        private readonly ISiteUriResolver _siteUriResolver;
 
         public ExternalReviewStore(IContentLoader contentLoader, NotificationOptions notificationOptions,
             IExternalReviewLinksRepository externalReviewLinksRepository,
             EmailNotificationProvider emailNotificationProvider,
-            ExternalReviewOptions externalReviewOptions, CurrentProject currentProject)
+            ExternalReviewOptions externalReviewOptions, CurrentProject currentProject,
+            ISiteUriResolver siteUriResolver)
         {
             _contentLoader = contentLoader;
             _notificationOptions = notificationOptions;
@@ -39,8 +41,8 @@ namespace AdvancedExternalReviews.ReviewLinksRepository
             _emailNotificationProvider = emailNotificationProvider;
             _externalReviewOptions = externalReviewOptions;
             _currentProject = currentProject;
+            _siteUriResolver = siteUriResolver;
         }
-
 
         private void HidePinCode(ExternalReviewLink externalReviewLink)
         {
@@ -130,7 +132,7 @@ namespace AdvancedExternalReviews.ReviewLinksRepository
         private async Task<bool> SendMail(ExternalReviewLink externalReviewLink, string email, string subject,
             string message)
         {
-            var linkUrl = new Uri(SiteDefinition.Current.SiteUrl, externalReviewLink.LinkUrl);
+            var linkUrl = new Uri(_siteUriResolver.GetUri(externalReviewLink.ContentLink), externalReviewLink.LinkUrl);
 
             message = message.Replace("[#link#]", linkUrl.ToString());
 


### PR DESCRIPTION
We don't need to find out the SiteDefinition ourselves because
there's already an api endpoint for this in Core that returns a
SiteDefinition instance for a given ContentReference.

The default implementation of the new ISiteUrlResolver will just find the current site's SiteUrl.
But it will be possible to override that with something custom.