### PR TITLE
Feature/split enabled to edit review and public review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/external
 src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/external-review-manage-links-component.js.map
 src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/external-review-component.js
 src/alloy/modules/_protected/advanced-cms.ExternalReviews/Views/external-review-component.js.map
+
+src/alloy/Properties/launchSettings.json

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ There are few settings related with external review. They are all set using Opti
  | ---- | ---- | ---- |
  | ContentPreviewUrl | externalContentView | path prefix added before token for "View" preview links |
  | IsEnabled | true | is the add-on enabled |
+ | IsPublicPreviewEnabled | true | is the add-on enabled for public previews, option to only enabled public previews and keeping the rest of the funtionality turned off. |
  | ReviewsUrl | externalContentReviews | path prefix added before token for "Edit" review links |
  | EmailSubject | [subject email template]|  email subject template |
  | EmailEdit | [email template] |email body template used for readonly content links |

--- a/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
+++ b/src/alloy/modules/_protected/advanced-cms.ExternalReviews/1.0.0/Scripts/initializer.js
@@ -16,7 +16,7 @@ define([
             this.inherited(arguments);
 
             var options = this._settings.options || {};
-            if (!options.isEnabled) {
+            if (!options.isPublicPreviewEnabled) {
                 return;
             }
 

--- a/src/external-reviews/BlocksPreview/BlocksTemplateCoordinator.cs
+++ b/src/external-reviews/BlocksPreview/BlocksTemplateCoordinator.cs
@@ -11,7 +11,7 @@ namespace AdvancedExternalReviews.BlocksPreview
         public static void OnTemplateResolved(object sender, TemplateResolverEventArgs args)
         {
             var options = ServiceLocator.Current.GetInstance<ExternalReviewOptions>();
-            if (!options.IsEnabled)
+            if (!options.IsEnabled && !options.IsPublicPreviewEnabled)
             {
                 return;
             }

--- a/src/external-reviews/ExternalReviewOptions.cs
+++ b/src/external-reviews/ExternalReviewOptions.cs
@@ -20,7 +20,7 @@ namespace AdvancedExternalReviews
         public bool IsEnabled { get; set; } = true;
 
         /// <summary>
-        /// Gets or sets if the plugin should be initialized in Edit Mode
+        /// Gets or sets if the plugin should be initialized in Public Mode
         /// </summary>
         public bool IsPublicPreviewEnabled { get; set; } = true;
 

--- a/src/external-reviews/ExternalReviewOptions.cs
+++ b/src/external-reviews/ExternalReviewOptions.cs
@@ -20,6 +20,11 @@ namespace AdvancedExternalReviews
         public bool IsEnabled { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets if the plugin should be initialized in Edit Mode
+        /// </summary>
+        public bool IsPublicPreviewEnabled { get; set; } = true;
+
+        /// <summary>
         /// URL used for displaying readonly version of page
         /// </summary>
         public string ContentPreviewUrl { get; set; } = "externalContentView";

--- a/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
+++ b/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
@@ -24,7 +24,8 @@ namespace AdvancedExternalReviews.ManageLinks
         {
             _options = options;
             _visitorGroupRepository = visitorGroupRepository;
-            IsAvailableForUserSelection = options.IsEnabled;
+            //IsAvailableForUserSelection = options.IsEnabled;
+            IsAvailableForUserSelection = options.IsPublicPreviewEnabled;
             LanguagePath = "/externalreviews/component";
             Categories = new[] {"content"};
             SortOrder = 1000;
@@ -46,6 +47,7 @@ namespace AdvancedExternalReviews.ManageLinks
                 base.Settings["availableVisitorGroups"] = _visitorGroupRepository.List();
                 base.Settings["pinCodeLength"] = _options.PinCodeSecurity.CodeLength;
                 base.Settings["isEnabled"] = _options.IsEnabled;
+                base.Settings["isPublicPreviewEnabled"] = _options.IsPublicPreviewEnabled;
                 base.Settings["prolongDays"] = _options.ProlongDays;
 
                 return base.Settings;

--- a/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
+++ b/src/external-reviews/ManageLinks/ExternalReviewLinksManageComponent.cs
@@ -24,7 +24,6 @@ namespace AdvancedExternalReviews.ManageLinks
         {
             _options = options;
             _visitorGroupRepository = visitorGroupRepository;
-            //IsAvailableForUserSelection = options.IsEnabled;
             IsAvailableForUserSelection = options.IsPublicPreviewEnabled;
             LanguagePath = "/externalreviews/component";
             Categories = new[] {"content"};

--- a/src/external-reviews/PagePreviewPartialRouter.cs
+++ b/src/external-reviews/PagePreviewPartialRouter.cs
@@ -36,7 +36,12 @@ namespace AdvancedExternalReviews
 
         public object RoutePartial(PageData content, SegmentContext segmentContext)
         {
-            if (!_externalReviewOptions.IsEnabled)
+            //if (!_externalReviewOptions.IsEnabled)
+            //{
+            //    return null;
+            //}
+
+            if (!_externalReviewOptions.IsPublicPreviewEnabled)
             {
                 return null;
             }

--- a/src/external-reviews/PagePreviewPartialRouter.cs
+++ b/src/external-reviews/PagePreviewPartialRouter.cs
@@ -36,11 +36,6 @@ namespace AdvancedExternalReviews
 
         public object RoutePartial(PageData content, SegmentContext segmentContext)
         {
-            //if (!_externalReviewOptions.IsEnabled)
-            //{
-            //    return null;
-            //}
-
             if (!_externalReviewOptions.IsPublicPreviewEnabled)
             {
                 return null;

--- a/src/ui/src/external-reviews-manage-links/external-review-manage-links-widget.tsx
+++ b/src/ui/src/external-reviews-manage-links/external-review-manage-links-widget.tsx
@@ -13,7 +13,7 @@ import res from "epi/i18n!epi/cms/nls/externalreviews";
  */
 export default declare([WidgetBase, _ContentContextMixin], {
     postCreate: function() {
-        if (!this.params.isEnabled) {
+        if (!this.params.isPublicPreviewEnabled) {
             return;
         }
 
@@ -43,7 +43,7 @@ export default declare([WidgetBase, _ContentContextMixin], {
         );
     },
     contextChanged: function() {
-        if (!this.params.isEnabled) {
+        if (!this.params.isPublicPreviewEnabled) {
             return;
         }
 
@@ -57,7 +57,7 @@ export default declare([WidgetBase, _ContentContextMixin], {
         this.store.load();
     },
     destroy: function() {
-        if (!this.params.isEnabled) {
+        if (!this.params.isPublicPreviewEnabled) {
             return;
         }
 


### PR DESCRIPTION
Split the addon is enabled in to two settings. One for the public preview and one for the rest. This to enabled the option to only use external page preview.