### PR TITLE
Skip appending project identifier when linking another site

### DIFF
--- a/build/version.props
+++ b/build/version.props
@@ -1,7 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>0.9.2</VersionPrefix>
+    <VersionPrefix>0.9.3</VersionPrefix>
     <VersionSuffix>developerbuild-000001</VersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
We use claims/cookie host-based authentication when using
pin security and can only support project items in a single
site (under a single hostname).
This commit makes sure to skip the project postfix if a found
link belongs to a different site and pin code validation is turned on.

#216