### PR TITLE
Skip appending project identifier when linking another site

### DIFF
--- a/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
+++ b/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
@@ -1,4 +1,5 @@
-﻿using EPiServer;
+﻿using Advanced.CMS.ExternalReviews.ReviewLinksRepository;
+using EPiServer;
 using EPiServer.Core;
 using EPiServer.Core.Internal;
 using EPiServer.Framework;
@@ -28,7 +29,8 @@ namespace Advanced.CMS.ExternalReviews.DraftContentAreaPreview
                         new PreviewUrlResolver(defaultUrlResolver, locator.GetInstance<IContentLoader>(),
                             locator.GetInstance<IPermanentLinkMapper>(), locator.GetInstance<IContentProviderManager>(),
                             locator.GetInstance<ExternalReviewState>(),
-                            locator.GetInstance<ExternalReviewUrlGenerator>()));
+                            locator.GetInstance<ExternalReviewUrlGenerator>(),
+                            locator.GetInstance<ISiteDefinitionResolver>()));
 
                 // Intercepted in order to return unpublished children in external review context
                 context.Services.Intercept<IContentLoader>(


### PR DESCRIPTION
We use claims/cookie host-based authentication when using pin security and can only support project items in a single site (under a single hostname).
This commit makes sure to skip the project postfix if a found link belongs to a different site and pin code security is enabled.

#216