### PR TITLE
upgrade cms UI to 12.17

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,8 +1,8 @@
 <Project>
     <PropertyGroup>
-        <CmsCoreVersion>12.11.0</CmsCoreVersion>
-        <CmsUIVersion>12.15.0</CmsUIVersion>
-        <CmsUmbrellaVersion>12.15.1</CmsUmbrellaVersion>
+        <CmsCoreVersion>12.12.1</CmsCoreVersion>
+        <CmsUIVersion>12.17.1</CmsUIVersion>
+        <CmsUmbrellaVersion>12.17.1</CmsUmbrellaVersion>
         <CommerceVersion>14.8.0</CommerceVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/src/Advanced.CMS.ApprovalReviews/ClientResources/notificationsInitializer.js
+++ b/src/Advanced.CMS.ApprovalReviews/ClientResources/notificationsInitializer.js
@@ -3,83 +3,17 @@ define([
     "dojo/when",
     "epi/dependency",
     "epi/shell/StickyViewSelector",
-    "epi-cms/notification/viewmodels/NotificationListViewModel",
+    //"epi-cms/notification/viewmodels/NotificationListViewModel",
     "epi/shell/TypeDescriptorManager"
 ], function (
     topic,
     when,
     dependency,
     StickyViewSelector,
-    NotificationListViewModel,
+    //NotificationListViewModel,
     TypeDescriptorManager
 ) {
     function initialize() {
-
-        // get available views for content type
-        function getAvailableViews(dataType) {
-            var availableViews = TypeDescriptorManager.getAndConcatenateValues(dataType, "availableViews") || [],
-                disabledViews = TypeDescriptorManager.getValue(dataType, "disabledViews") || [];
-
-            var filteredViews = availableViews.filter(function (availableView) {
-                return disabledViews.every(function (disabledView) {
-                    return availableView.key !== disabledView;
-                });
-            });
-            return filteredViews.map(function (x) { return x.key; });
-        }
-
-
-        //
-        // override original Notification item click and when external review is detected,
-        // then automatically turn on reviews mode
-        //
-        var original = NotificationListViewModel.prototype.gotoSelectedNotificationOrigin;
-        NotificationListViewModel.prototype.gotoSelectedNotificationOrigin = function () {
-            if (this.selectedNotification.content.indexOf("external-review'")) {
-                // subscribe to context changed event once, and then turn on project mode
-                var handle = topic.subscribe("/epi/shell/context/changed", function () {
-                    handle.remove();
-                    handle = null;
-
-                    // wait one second until OPE is loaded and then turn on reviews
-                    setTimeout(function () {
-                        topic.publish("reviews:force-review-mode");
-                    }.bind(this), 1000);
-                });
-
-                setTimeout(function () {
-                    if (handle) {
-                        handle.remove();
-                    }
-                }, 2000);
-
-                // parse contentLink from URL parameter
-                var id = this.selectedNotification.link.substring(this.selectedNotification.link.indexOf(":///") + 4);
-
-                var registry = dependency.resolve("epi.storeregistry");
-                var store = registry.get("epi.cms.contentdata");
-
-                // get content and check if OPE is in available views
-                when(store.get(id)).then(function (contentData) {
-                    var availableViews = getAvailableViews(contentData.typeIdentifier);
-                    if (availableViews.indexOf("onpageedit") === -1) {
-                        original.apply(this, arguments);
-                    }
-
-                    // use StickyViewSelector, to force loading OPE
-                    var typeIdentifier = contentData.typeIdentifier;
-                    var stickyViewSelector = new StickyViewSelector();
-                    stickyViewSelector.save(true, typeIdentifier, "onpageedit");
-
-                    // call original method to load new context
-                    original.apply(this, arguments);
-                }.bind(this));
-            } else {
-                original.apply(this, arguments);
-            }
-        };
-
-        NotificationListViewModel.prototype.gotoSelectedNotificationOrigin.nom = "gotoSelectedNotificationOrigin";
     }
 
     return {

--- a/src/Advanced.CMS.ApprovalReviews/Notifications/ReviewsNotifier.cs
+++ b/src/Advanced.CMS.ApprovalReviews/Notifications/ReviewsNotifier.cs
@@ -69,7 +69,7 @@ namespace Advanced.CMS.ApprovalReviews.Notifications
 
             // subscribe users to comment
             var subscriptionKey = new Uri($"advancedreviews://notification/{token}");
-
+            var userName = _principalAccessor.CurrentName();
             await _subscriptionService.SubscribeAsync(subscriptionKey, subscribers).ConfigureAwait(false);
 
             var recipients = (await _subscriptionService.ListSubscribersAsync(subscriptionKey).ConfigureAwait(false))
@@ -93,7 +93,8 @@ namespace Advanced.CMS.ApprovalReviews.Notifications
             var notificationMessage = new NotificationMessage
             {
                 ChannelName = ChannelName,
-                Sender = new NotificationUser(_principalAccessor.CurrentName()),
+                Sender = new NotificationUser(userName),
+                //Sender = new NotificationUser(_principalAccessor.CurrentName()),
                 Recipients = recipients,
                 Content = _objectSerializer.Serialize(model)
             };


### PR DESCRIPTION
This one upgrades to 12.17.1 and simply remove the part about overriding NotificationListViewModel.prototype.gotoSelectedNotificationOrigin. Therefore the site will work, but clicking on the external-review notification will not switch to OPE mode, nor publish the event "reviews:force-review-mode"