### PR TITLE
Fallback to master language start page version

### DIFF
--- a/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
+++ b/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/DraftContentAreaPreviewInitializerInitializer.cs
@@ -1,10 +1,8 @@
-﻿using Advanced.CMS.ExternalReviews.ReviewLinksRepository;
-using EPiServer;
+﻿using EPiServer;
 using EPiServer.Core;
 using EPiServer.Core.Internal;
 using EPiServer.Framework;
 using EPiServer.Framework.Initialization;
-using EPiServer.Globalization;
 using EPiServer.Security;
 using EPiServer.ServiceLocation;
 using EPiServer.Web;
@@ -16,7 +14,7 @@ namespace Advanced.CMS.ExternalReviews.DraftContentAreaPreview
     /// <summary>
     /// Register ContentArea draft preview
     /// </summary>
-    [ModuleDependency(typeof(EPiServer.Web.InitializationModule))]
+    [ModuleDependency(typeof(InitializationModule))]
     public class DraftContentAreaPreviewInitializerInitializer : IConfigurableModule
     {
         public void ConfigureContainer(ServiceConfigurationContext context)
@@ -47,8 +45,7 @@ namespace Advanced.CMS.ExternalReviews.DraftContentAreaPreview
                 // Intercepted in order to return unpublished content items
                 context.Services.Intercept<IPublishedStateAssessor>(
                     (locator, defaultPublishedStateAssessor) =>
-                        new PublishedStateAssessorDecorator(defaultPublishedStateAssessor,
-                            locator.GetInstance<LanguageResolver>(), locator.GetInstance<ExternalReviewState>()));
+                        new PublishedStateAssessorDecorator(defaultPublishedStateAssessor, locator.GetInstance<ExternalReviewState>()));
 
                 // Intercepted in order to not filter out content without Everyone access
                 context.Services.Intercept<IContentAccessEvaluator>(

--- a/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/PublishedStateAssessorDecorator.cs
+++ b/src/Advanced.CMS.ExternalReviews/DraftContentAreaPreview/PublishedStateAssessorDecorator.cs
@@ -1,19 +1,15 @@
 ﻿using EPiServer.Core;
-using EPiServer.Globalization;
 
 namespace Advanced.CMS.ExternalReviews.DraftContentAreaPreview
 {
     public class PublishedStateAssessorDecorator : IPublishedStateAssessor
     {
         private readonly IPublishedStateAssessor _defaultService;
-        private readonly LanguageResolver _languageResolver;
         private readonly ExternalReviewState _externalReviewState;
 
-        public PublishedStateAssessorDecorator(IPublishedStateAssessor defaultService,
-            LanguageResolver languageResolver, ExternalReviewState externalReviewState)
+        public PublishedStateAssessorDecorator(IPublishedStateAssessor defaultService, ExternalReviewState externalReviewState)
         {
             _defaultService = defaultService;
-            _languageResolver = languageResolver;
             _externalReviewState = externalReviewState;
         }
 
@@ -28,8 +24,7 @@ namespace Advanced.CMS.ExternalReviews.DraftContentAreaPreview
 
                 if (_externalReviewState.CustomLoaded.Contains(content.ContentLink.ToString()))
                 {
-                    var cachedContent =
-                        _externalReviewState.GetCachedContent(_languageResolver.GetPreferredCulture(), content.ContentLink);
+                    var cachedContent = _externalReviewState.GetCachedContent(content.ContentLink);
                     if (cachedContent != null)
                     {
                         return true;

--- a/src/Advanced.CMS.ExternalReviews/EditReview/PageEditPartialRouter.cs
+++ b/src/Advanced.CMS.ExternalReviews/EditReview/PageEditPartialRouter.cs
@@ -18,17 +18,19 @@ namespace Advanced.CMS.ExternalReviews.EditReview
         private readonly ProjectContentResolver _projectContentResolver;
         private readonly IContentLanguageAccessor _contentLanguageAccessor;
         private readonly ExternalReviewState _externalReviewState;
+        private readonly IContentVersionRepository _contentVersionRepository;
 
         public PageEditPartialRouter(IExternalReviewLinksRepository externalReviewLinksRepository,
             ExternalReviewOptions externalReviewOptions,
             ProjectContentResolver projectContentResolver, IContentLanguageAccessor contentLanguageAccessor,
-            ExternalReviewState externalReviewState)
+            ExternalReviewState externalReviewState, IContentVersionRepository contentVersionRepository)
         {
             _externalReviewLinksRepository = externalReviewLinksRepository;
             _externalReviewOptions = externalReviewOptions;
             _projectContentResolver = projectContentResolver;
             _contentLanguageAccessor = contentLanguageAccessor;
             _externalReviewState = externalReviewState;
+            _contentVersionRepository = contentVersionRepository;
         }
 
         public PartialRouteData GetPartialVirtualPath(IContent content, UrlGeneratorContext urlGeneratorContext)
@@ -58,11 +60,13 @@ namespace Advanced.CMS.ExternalReviews.EditReview
                 return null;
             }
 
+            var version = _contentVersionRepository.Load(externalReviewLink.ContentLink);
+            _contentLanguageAccessor.Language = new CultureInfo(version.LanguageBranch);
+
             _externalReviewState.ProjectId = externalReviewLink.ProjectId;
             _externalReviewState.IsEditLink = true;
             _externalReviewState.Token = token;
-
-            _contentLanguageAccessor.Language = new CultureInfo(content.LanguageBranch());
+            _externalReviewState.PreferredLanguage = version.LanguageBranch;
 
             try
             {

--- a/src/Advanced.CMS.ExternalReviews/ExternalReviewState.cs
+++ b/src/Advanced.CMS.ExternalReviews/ExternalReviewState.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Globalization;
 using EPiServer.Core;
 using EPiServer.ServiceLocation;
 using Microsoft.AspNetCore.Http;
@@ -23,6 +22,12 @@ namespace Advanced.CMS.ExternalReviews
         {
             get => _httpContextAccessor.HttpContext?.Items["Token"] as string;
             set => _httpContextAccessor.HttpContext.Items["Token"] = value;
+        }
+
+        public string PreferredLanguage
+        {
+            get => _httpContextAccessor.HttpContext?.Items["PreferredLanguage"] as string;
+            set => _httpContextAccessor.HttpContext.Items["PreferredLanguage"] = value;
         }
 
         public bool IsEditLink
@@ -88,18 +93,18 @@ namespace Advanced.CMS.ExternalReviews
             return _httpContextAccessor.HttpContext?.Items[key] as ConcurrentDictionary<string, IContent>;
         }
 
-        public IContent GetCachedContent(CultureInfo preferredCulture, ContentReference contentLink)
+        public IContent GetCachedContent(ContentReference contentLink)
         {
-            if (GetCachedLinksDictionary().TryGetValue(preferredCulture.Name + "_" + contentLink.ToReferenceWithoutVersion(), out var result))
+            if (GetCachedLinksDictionary().TryGetValue(PreferredLanguage + "_" + contentLink.ToReferenceWithoutVersion(), out var result))
             {
                 return result;
             }
             return null;
         }
 
-        public void SetCachedLink(CultureInfo preferredCulture, IContent contentLink)
+        public void SetCachedLink(IContent contentLink)
         {
-            GetCachedLinksDictionary()[preferredCulture.Name + "_" + contentLink.ContentLink.ToReferenceWithoutVersion()] = contentLink;
+            GetCachedLinksDictionary()[PreferredLanguage + "_" + contentLink.ContentLink.ToReferenceWithoutVersion()] = contentLink;
         }
     }
 }

--- a/src/Advanced.CMS.ExternalReviews/PreviewUrlResolver.cs
+++ b/src/Advanced.CMS.ExternalReviews/PreviewUrlResolver.cs
@@ -172,8 +172,8 @@ namespace Advanced.CMS.ExternalReviews
             if (contentRouteData.RemainingPath.StartsWith($"{_externalReviewOptions.Service.ContentPreviewUrl}/", StringComparison.CurrentCultureIgnoreCase))
             {
                 // If we failed to route then it means that a start page in the same language does not exist and our partial routers will not be able to step in
-                // We need to fallback to master language
-                if (contentRouteData.Content == null)
+                // We need to fallback to master language also if the translated start page is not published
+                if (contentRouteData.Content == null || !contentRouteData.Content.IsPublished())
                 {
                     var masterLanguage = LanguageSelector.AutoDetect().LanguageBranch;
                     urlBuilder.Path = urlBuilder.Path.Replace($"/{contentRouteData.RouteLanguage}", $"/{masterLanguage}");

--- a/src/Alloy.Sample/Business/Rendering/AlloyContentAreaRenderer.cs
+++ b/src/Alloy.Sample/Business/Rendering/AlloyContentAreaRenderer.cs
@@ -45,7 +45,7 @@ namespace Alloy.Sample.Business.Rendering
 
         private static string GetTypeSpecificCssClasses(ContentAreaItem contentAreaItem, IContentRepository contentRepository)
         {
-            var content = contentAreaItem.GetContent();
+            var content = contentAreaItem.LoadContent();
             var cssClass = content == null ? String.Empty : content.GetOriginalType().Name.ToLowerInvariant();
 
             var customClassContent = content as ICustomCssInContentArea;


### PR DESCRIPTION
If the default router fails to route to the content we should
retry with master language as the first url segment.
It may happen that user has a translated page but does not have
a published start page in that version.

Fallback to master start page if not published
We also need a trick with start page fallback if the translated
start page is not published

Make sure to use the language token was created in
We will cache the preferred language in HttpContext.Items and
use it instead of relying solely on IContentLanguageAccessor

Closes #221