### PR TITLE
Issue #258 - Improve performance of GetProjectReference in ProjectContentResolver

### DIFF
--- a/src/Advanced.CMS.ExternalReviews/ProjectContentResolver.cs
+++ b/src/Advanced.CMS.ExternalReviews/ProjectContentResolver.cs
@@ -20,12 +20,10 @@ internal class ProjectContentResolver
 
     public ContentReference GetProjectReference(ContentReference contentLink, int projectId, string language)
     {
-        var items = _projectRepository.ListItems(projectId);
-
-        var item = items.FirstOrDefault(
-            x => x.ContentLink.ToReferenceWithoutVersion() == contentLink.ToReferenceWithoutVersion()
-                 && (x.Language?.Name == language)
-        );
+        var item = _projectRepository
+            .GetItems(new[] { contentLink.ToReferenceWithoutVersion() })
+            .Where(x => x.ProjectID == projectId && x.Language.Name == language)
+            .FirstOrDefault();
         return item?.ContentLink;
     }
 


### PR DESCRIPTION
Fix for issue #258 

Change approach of GetProjectReference method to get project items from ContentLink directly, then checking if any match the projectId, instead of getting all items in project and iterating all to check for a match of the contentLink.

This will be an improvement on performance assuming the number of projectItems matching the Contentlink in any project is less than the total number of items in a project.