### PR TITLE
fix: blocks were not showing updates

### DIFF
--- a/src/Advanced.CMS.ExternalReviews/CustomContentLoaderInitialization.cs
+++ b/src/Advanced.CMS.ExternalReviews/CustomContentLoaderInitialization.cs
@@ -53,7 +53,7 @@ internal class CustomContentLoaderInitialization : IInitializableModule
 
         var externalReviewLinksRepository = ServiceLocator.Current.GetInstance<IExternalReviewLinksRepository>();
         var externalReviewLink = externalReviewLinksRepository.GetContentByToken(externalReviewState.Token);
-        if (!externalReviewLink.IsPreviewableLink())
+        if (externalReviewLink!= null && externalReviewLink.IsExpired())
         {
             return;
         }


### PR DESCRIPTION
Fix: Blocks were not getting the unpublished version when an external link has been created in edit mode. We will appreciate if you could review fix and publish the latest version. Its a blocker for us. 